### PR TITLE
Changed user show page to show only message and link to questions

### DIFF
--- a/QA-webapp/app/views/users/show.html.erb
+++ b/QA-webapp/app/views/users/show.html.erb
@@ -1,14 +1,4 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Username:</strong>
-  <%= @user.username %>
-</p>
 
-<p>
-  <strong>Password:</strong>
-  <%= @user.password %>
-</p>
-
-<%= link_to 'Edit', edit_user_path(@user) %> |
-<%= link_to 'Back', users_path %>
+<%= link_to 'View Questions', questions_path %>


### PR DESCRIPTION
When a user signed up it brought them to a page that said "The user successfully signed up." showed username and password, and had links to edit and back. I changed this page to include only the message and a link to view all questions. The backend work is done for user signup.